### PR TITLE
Change <bluetooth/uuid.h> include to "uuid.h" in src/att.h

### DIFF
--- a/src/att.h
+++ b/src/att.h
@@ -23,7 +23,7 @@
  */
 
 #include "bluetooth.h"
-#include <bluetooth/uuid.h>
+#include "uuid.h"
 #include <glib.h>
 
 /* Attribute Protocol Opcodes */


### PR DESCRIPTION
Build of `libgatt` yielded `src/att.h:26:28: fatal error: bluetooth/uuid.h: No such file or directory`. 

This pull request prevents that error.

```
sudo apt-get install glib2.0
git clone https://github.com/jacklund/libgatt.git
cd libgatt
./configure
make

make  all-am
make[1]: Entering directory '/home/chip/libgatt'
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.      -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include   -g -O2 -MT src/libgatt_la-att.lo -MD -MP -MF src/.deps/libgatt_la-att.Tpo -c -o src/libgatt_la-att.lo `test -f 'src/att.c' || echo './'`src/att.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I/usr/include/glib-2.0 -I/usr/lib/arm-linux-gnueabihf/glib-2.0/include -g -O2 -MT src/libgatt_la-att.lo -MD -MP -MF src/.deps/libgatt_la-att.Tpo -c src/att.c  -fPIC -DPIC -o src/.libs/libgatt_la-att.o
In file included from src/att.c:37:0:
src/att.h:26:28: fatal error: bluetooth/uuid.h: No such file or directory
 #include <bluetooth/uuid.h>
                            ^
compilation terminated.
Makefile:434: recipe for target 'src/libgatt_la-att.lo' failed
make[1]: *** [src/libgatt_la-att.lo] Error 1
make[1]: Leaving directory '/home/chip/libgatt'
Makefile:280: recipe for target 'all' failed
make: *** [all] Error 2

```